### PR TITLE
Persist cookies in config.yml

### DIFF
--- a/base/config.yml
+++ b/base/config.yml
@@ -1,3 +1,4 @@
-username: gettc
-password: algorithm
-version: 2.0.1
+account: !ruby/object:Gettc::Account
+  username: gettc
+  password: algorithm
+version: 2.1.0

--- a/bin/gettc
+++ b/bin/gettc
@@ -24,7 +24,13 @@ def load_config
     replace_config
   end
 
-  $account = Account.new(config["username"], config["password"])
+  $account = config["account"]
+end
+
+def save_config
+  File.open(File.join($config_dir, "config.yml"), 'w') { |f|
+    f.write({"account" => $account, "version" => Gem::Version.new(VERSION).version}.to_yaml)
+  }
 end
 
 def init
@@ -73,9 +79,12 @@ gettc reset: Bring all settings to default state.
   else
     gettc(command.to_i)
   end
+
 rescue StandardError => err
   puts err
   exit -1
+ensure
+  save_config
 end
 
 init

--- a/dist/config.yml
+++ b/dist/config.yml
@@ -1,3 +1,4 @@
-username: gettc
-password: algorithm
-version: 2.0
+account: !ruby/object:Gettc::Account
+  username: gettc
+  password: algorithm
+version: 2.1.0

--- a/lib/gettc/account.rb
+++ b/lib/gettc/account.rb
@@ -1,10 +1,11 @@
 module Gettc
   class Account
-    attr_accessor :username, :password
+    attr_accessor :username, :password, :token
 
-    def initialize(username, password)
+    def initialize(username, password, token = nil)
       @username = username
       @password = password
+      @token = token
     end
 
     def to_s

--- a/lib/gettc/download.rb
+++ b/lib/gettc/download.rb
@@ -6,6 +6,7 @@ require "json"
 
 require "gettc/account"
 
+
 module Gettc
   class DownloadError < StandardError
   end
@@ -182,6 +183,9 @@ module Gettc
     end
 
     def get_cookie
+      if @account.token
+        return @account.token
+      end
       jwt_token_response = JSON(post_json("http://api.topcoder.com/v2/auth", {
         username: @account.username,
         password: @account.password
@@ -205,7 +209,7 @@ module Gettc
       unless CGI::Cookie.parse(raw_cookie).has_key?("tcsso")
         raise DownloadError.new(raw_cookie, "Server refused to send a tcsso cookie")
       end
-      raw_cookie
+      @account.token = raw_cookie
     end
   end
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Gettc
-  VERSION = "2.0.1"
+  VERSION = "2.1.0"
 end

--- a/test/gettc/generate_test.rb
+++ b/test/gettc/generate_test.rb
@@ -61,7 +61,7 @@ class GenerateTest < Test::Unit::TestCase
 
   def count_files(subdir)
     full_path = File.join(@target_dir, @problem["name"], subdir)
-    Dir.new(full_path).entries.reject { |name| [".", ".."].include?(name) }.size
+    File.directory?(full_path) ? Dir.new(full_path).entries.reject { |name| [".", ".."].include?(name) }.size : 0
   end
 
   def assert_file_exists(filename)


### PR DESCRIPTION
I'm preparing some new functionality for gettc which involves making a lot of consecutive API calls. So gettc's current behaviour of requesting a new API token on every invocation is painful. This patch caches the cookie in `config.yml` and re-uses it.

Let me know if you'd prefer to keep the cookie in a separate file rather than in `config.yml`!